### PR TITLE
blockstore: Adding Stat method to map from Cid to BlockSize

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -40,6 +40,9 @@ type Blockstore interface {
 	Has(*cid.Cid) (bool, error)
 	Get(*cid.Cid) (blocks.Block, error)
 
+	// GetSize returns the CIDs mapped BlockSize
+	GetSize(*cid.Cid) (int, error)
+
 	// Put puts a given block to the underlying datastore
 	Put(blocks.Block) error
 
@@ -181,6 +184,18 @@ func (bs *blockstore) PutMany(blocks []blocks.Block) error {
 
 func (bs *blockstore) Has(k *cid.Cid) (bool, error) {
 	return bs.datastore.Has(dshelp.CidToDsKey(k))
+}
+
+func (bs *blockstore) GetSize(k *cid.Cid) (int, error) {
+	maybeData, err := bs.datastore.Get(dshelp.CidToDsKey(k))
+	if err != nil {
+		return -1, err
+	}
+	bdata, ok := maybeData.([]byte)
+	if !ok {
+		return -1, ErrValueTypeMismatch
+	}
+	return len(bdata), nil
 }
 
 func (bs *blockstore) DeleteBlock(k *cid.Cid) error {

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -54,6 +54,39 @@ func TestPutThenGetBlock(t *testing.T) {
 	}
 }
 
+func TestPutThenGetSizeBlock(t *testing.T) {
+	bs := NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+	block := blocks.NewBlock([]byte("some data"))
+	missingBlock := blocks.NewBlock([]byte("missingBlock"))
+	emptyBlock := blocks.NewBlock([]byte{})
+
+	err := bs.Put(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockSize, err := bs.GetSize(block.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(block.RawData()) != blockSize {
+		t.Fail()
+	}
+
+	err = bs.Put(emptyBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if blockSize, err := bs.GetSize(emptyBlock.Cid()); blockSize != 0 || err != nil {
+		t.Fatal(err)
+	}
+
+	if blockSize, err := bs.GetSize(missingBlock.Cid()); blockSize != -1 || err == nil {
+		t.Fatal("getsize returned invalid result")
+	}
+}
+
 func TestHashOnRead(t *testing.T) {
 	orginalDebug := u.Debug
 	defer (func() {

--- a/bloom_cache.go
+++ b/bloom_cache.go
@@ -133,6 +133,10 @@ func (b *bloomcache) Has(k *cid.Cid) (bool, error) {
 	return b.blockstore.Has(k)
 }
 
+func (b *bloomcache) GetSize(k *cid.Cid) (int, error) {
+  return b.blockstore.GetSize(k)
+}
+
 func (b *bloomcache) Get(k *cid.Cid) (blocks.Block, error) {
 	if has, ok := b.hasCached(k); ok && !has {
 		return nil, ErrNotFound

--- a/bloom_cache_test.go
+++ b/bloom_cache_test.go
@@ -45,13 +45,18 @@ func TestPutManyAddsToBloom(t *testing.T) {
 
 	block1 := blocks.NewBlock([]byte("foo"))
 	block2 := blocks.NewBlock([]byte("bar"))
+	emptyBlock := blocks.NewBlock([]byte{})
 
-	cachedbs.PutMany([]blocks.Block{block1})
+	cachedbs.PutMany([]blocks.Block{block1, emptyBlock})
 	has, err := cachedbs.Has(block1.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !has {
+	blockSize, err := cachedbs.GetSize(block1.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blockSize == -1 || !has {
 		t.Fatal("added block is reported missing")
 	}
 
@@ -59,8 +64,24 @@ func TestPutManyAddsToBloom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if has {
+	blockSize, err = cachedbs.GetSize(block2.Cid())
+	if err != nil && err != ds.ErrNotFound {
+		t.Fatal(err)
+	}
+	if blockSize > -1 || has {
 		t.Fatal("not added block is reported to be in blockstore")
+	}
+
+	has, err = cachedbs.Has(emptyBlock.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockSize, err = cachedbs.GetSize(emptyBlock.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blockSize != 0 || !has {
+		t.Fatal("added block is reported missing")
 	}
 }
 

--- a/idstore.go
+++ b/idstore.go
@@ -41,6 +41,14 @@ func (b *idstore) Has(k *cid.Cid) (bool, error) {
 	return b.bs.Has(k)
 }
 
+func (b *idstore) GetSize(k *cid.Cid) (int, error) {
+	isId, bdata := extractContents(k)
+	if isId {
+		return len(bdata), nil
+	}
+	return b.bs.GetSize(k)
+}
+
 func (b *idstore) Get(k *cid.Cid) (blocks.Block, error) {
 	isId, bdata := extractContents(k)
 	if isId {

--- a/idstore_test.go
+++ b/idstore_test.go
@@ -21,6 +21,8 @@ func TestIdStore(t *testing.T) {
 	idblock1, _ := blk.NewBlockWithCid([]byte("idhash1"), idhash1)
 	hash1, _ := cid.NewPrefixV1(cid.Raw, mh.SHA2_256).Sum([]byte("hash1"))
 	block1, _ := blk.NewBlockWithCid([]byte("hash1"), hash1)
+	emptyHash, _ := cid.NewPrefixV1(cid.Raw, mh.SHA2_256).Sum([]byte("emptyHash"))
+	emptyBlock, _ := blk.NewBlockWithCid([]byte{}, emptyHash)
 
 	ids, cb := createTestStores()
 
@@ -56,9 +58,29 @@ func TestIdStore(t *testing.T) {
 		t.Fatal("normal block not added to datastore")
 	}
 
+	blockSize, _ := ids.GetSize(hash1)
+	if blockSize == -1 {
+		t.Fatal("normal block not added to datastore")
+	}
+
 	_, err = ids.Get(hash1)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	err = ids.Put(emptyBlock)
+	if err != nil {
+		t.Fatalf("Put() failed on normal block: %v", err)
+	}
+
+	have, _ = ids.Has(emptyHash)
+	if !have {
+		t.Fatal("normal block not added to datastore")
+	}
+
+	blockSize, _ = ids.GetSize(emptyHash)
+	if blockSize != 0 {
+		t.Fatal("normal block not added to datastore")
 	}
 
 	cb.f = failIfPassThough
@@ -76,6 +98,16 @@ func TestIdStore(t *testing.T) {
 	have, _ = ids.Has(hash1)
 	if have {
 		t.Fatal("normal block not deleted from datastore")
+	}
+
+	blockSize, _ = ids.GetSize(hash1)
+	if blockSize > -1 {
+		t.Fatal("normal block not deleted from datastore")
+	}
+
+	err = ids.DeleteBlock(emptyHash)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	idhash2, _ := cid.NewPrefixV1(cid.Raw, mh.ID).Sum([]byte("idhash2"))


### PR DESCRIPTION
Performant way to map from Cid to BlockSize. 

Helps resolve issue: [https://github.com/ipfs/go-ipfs/issues/4378#issuecomment-399777298](https://github.com/ipfs/go-ipfs/issues/4378#issuecomment-399777298)
@whyrusleeping @kevina @magik6k 

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>