### PR TITLE
cache: switch to 2q

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ipfs/go-ipfs-blockstore
 
 require (
 	github.com/hashicorp/golang-lru v0.5.1
-	github.com/ipfs/bbloom v0.0.1
+	github.com/ipfs/bbloom v0.0.2
 	github.com/ipfs/go-block-format v0.0.1
 	github.com/ipfs/go-cid v0.0.1
 	github.com/ipfs/go-datastore v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJ
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/ipfs/bbloom v0.0.1 h1:s7KkiBPfxCeDVo47KySjK0ACPc5GJRUxFpdyWEuDjhw=
-github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
+github.com/ipfs/bbloom v0.0.2 h1:4yJnWd/k7Hk5cCmF/25PA2BXhAFifdb/KjTlp2b20Yw=
+github.com/ipfs/bbloom v0.0.2/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
 github.com/ipfs/go-block-format v0.0.1 h1:GjLpqsPNn2KbzA2GuG+hsUyxMhQ1xXgffWqWOee9e9o=
 github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=


### PR DESCRIPTION
Due to patent concerns in closed-source downstream products:
https://github.com/ipfs/go-ipfs/issues/6590