### PR TITLE
return the correct size when only "has" is cached

### DIFF
--- a/arc_cache.go
+++ b/arc_cache.go
@@ -86,10 +86,15 @@ func (b *arccache) Has(k cid.Cid) (bool, error) {
 
 func (b *arccache) GetSize(k cid.Cid) (int, error) {
 	if has, blockSize, ok := b.hasCached(k); ok {
-		if has {
+		if !has {
+			// don't have it, return
+			return -1, ErrNotFound
+		}
+		if blockSize >= 0 {
+			// have it and we know the size
 			return blockSize, nil
 		}
-		return -1, ErrNotFound
+		// we have it but don't know the size, ask the datastore.
 	}
 	blockSize, err := b.blockstore.GetSize(k)
 	if err == ErrNotFound {

--- a/arc_cache_test.go
+++ b/arc_cache_test.go
@@ -123,7 +123,7 @@ func TestGetFillsCache(t *testing.T) {
 		t.Fatal("has returned invalid result")
 	}
 	if blockSize, err := arc.GetSize(exampleBlock.Cid()); blockSize == -1 || err != nil {
-		t.Fatal("getsize returned invalid result")
+		t.Fatal("getsize returned invalid result", blockSize, err)
 	}
 }
 
@@ -183,6 +183,25 @@ func TestGetSizeAfterSucessfulGetIsCached(t *testing.T) {
 
 	trap("has hit datastore", cd, t)
 	arc.GetSize(exampleBlock.Cid())
+}
+
+func TestGetSizeAfterSucessfulHas(t *testing.T) {
+	arc, bs, _ := createStores(t)
+
+	bs.Put(exampleBlock)
+	has, err := arc.Has(exampleBlock.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Fatal("expected to have block")
+	}
+
+	if size, err := arc.GetSize(exampleBlock.Cid()); err != nil {
+		t.Fatal(err)
+	} else if size != len(exampleBlock.RawData()) {
+		t.Fatalf("expected size %d, got %d", len(exampleBlock.RawData()), size)
+	}
 }
 
 func TestGetSizeMissingZeroSizeBlock(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/ipfs/go-metrics-interface v0.0.1
 	github.com/multiformats/go-multihash v0.0.10
 )
+
+go 1.12

--- a/go.sum
+++ b/go.sum
@@ -10,14 +10,10 @@ github.com/gxed/hashland/keccakpg v0.0.1 h1:wrk3uMNaMxbXiHibbPO4S0ymqJMm41WiudyF
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJu4ZbSc=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
-github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
-github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/go-block-format v0.0.1 h1:GjLpqsPNn2KbzA2GuG+hsUyxMhQ1xXgffWqWOee9e9o=
-github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
@@ -92,6 +88,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXT
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 h1:C2F/nMkR/9sfUTpvR3QrjBuTdvMUC/cFajkphs1YLQo=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Without this, we'd return -1 if we'd previously called `Has`. I'm pretty sure we _always_ call `GetSize` (at least from bitswap) but we need to fix this regardless.