### PR TITLE
fix: remove HashOnRead

### DIFF
--- a/arc_cache.go
+++ b/arc_cache.go
@@ -155,10 +155,6 @@ func (b *arccache) PutMany(bs []blocks.Block) error {
 	return nil
 }
 
-func (b *arccache) HashOnRead(enabled bool) {
-	b.blockstore.HashOnRead(enabled)
-}
-
 func (b *arccache) cacheHave(c cid.Cid, have bool) {
 	b.arc.Add(string(c.Hash()), cacheHave(have))
 }

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -136,14 +136,14 @@ func TestPutUsesHas(t *testing.T) {
 	}
 }
 
-func TestHashOnRead(t *testing.T) {
+func TestValidatingBlockstore(t *testing.T) {
 	orginalDebug := u.Debug
 	defer (func() {
 		u.Debug = orginalDebug
 	})()
 	u.Debug = false
 
-	bs := NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+	bs := ValidatingBlockstore{NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))}
 	bl := blocks.NewBlock([]byte("some data"))
 	blBad, err := blocks.NewBlockWithCid([]byte("some other data"), bl.Cid())
 	if err != nil {
@@ -152,7 +152,6 @@ func TestHashOnRead(t *testing.T) {
 	bl2 := blocks.NewBlock([]byte("some other data"))
 	bs.Put(blBad)
 	bs.Put(bl2)
-	bs.HashOnRead(true)
 
 	if _, err := bs.Get(bl.Cid()); err != ErrHashMismatch {
 		t.Fatalf("expected '%v' got '%v'\n", ErrHashMismatch, err)

--- a/bloom_cache.go
+++ b/bloom_cache.go
@@ -183,10 +183,6 @@ func (b *bloomcache) PutMany(bs []blocks.Block) error {
 	return nil
 }
 
-func (b *bloomcache) HashOnRead(enabled bool) {
-	b.blockstore.HashOnRead(enabled)
-}
-
 func (b *bloomcache) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return b.blockstore.AllKeysChan(ctx)
 }

--- a/idstore.go
+++ b/idstore.go
@@ -77,10 +77,6 @@ func (b *idstore) PutMany(bs []blocks.Block) error {
 	return b.bs.PutMany(toPut)
 }
 
-func (b *idstore) HashOnRead(enabled bool) {
-	b.bs.HashOnRead(enabled)
-}
-
 func (b *idstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return b.bs.AllKeysChan(ctx)
 }

--- a/validating_blockstore.go
+++ b/validating_blockstore.go
@@ -1,0 +1,26 @@
+package blockstore
+
+import (
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+)
+
+// ValidatingBlockstore validates blocks on get.
+type ValidatingBlockstore struct {
+	Blockstore
+}
+
+func (bs *ValidatingBlockstore) Get(c cid.Cid) (blocks.Block, error) {
+	block, err := bs.Blockstore.Get(c)
+	if err != nil {
+		return nil, err
+	}
+	rbcid, err := c.Prefix().Sum(block.RawData())
+	if err != nil {
+		return nil, err
+	}
+	if !rbcid.Equals(c) {
+		return nil, ErrHashMismatch
+	}
+	return block, nil
+}


### PR DESCRIPTION
Instead, provide a simple `ValidatingBlockstore` wrapper. This:

1. Isn't racy (fixes #49).
2. Keeps the base blockstore simple.


Really, "HashOnRead" should never have been a part of the blockstore API in the
first place.