### PR TITLE
wire a context in most of the Blockstore/Datastore methods

### DIFF
--- a/arc_cache.go
+++ b/arc_cache.go
@@ -35,13 +35,13 @@ func newARCCachedBS(ctx context.Context, bs Blockstore, lruSize int) (*arccache,
 	return c, nil
 }
 
-func (b *arccache) DeleteBlock(k cid.Cid) error {
+func (b *arccache) DeleteBlock(ctx context.Context, k cid.Cid) error {
 	if has, _, ok := b.hasCached(k); ok && !has {
 		return nil
 	}
 
 	b.arc.Remove(k) // Invalidate cache before deleting.
-	err := b.blockstore.DeleteBlock(k)
+	err := b.blockstore.DeleteBlock(ctx, k)
 	if err == nil {
 		b.cacheHave(k, false)
 	}
@@ -72,11 +72,11 @@ func (b *arccache) hasCached(k cid.Cid) (has bool, size int, ok bool) {
 	return false, -1, false
 }
 
-func (b *arccache) Has(k cid.Cid) (bool, error) {
+func (b *arccache) Has(ctx context.Context, k cid.Cid) (bool, error) {
 	if has, _, ok := b.hasCached(k); ok {
 		return has, nil
 	}
-	has, err := b.blockstore.Has(k)
+	has, err := b.blockstore.Has(ctx, k)
 	if err != nil {
 		return false, err
 	}
@@ -84,7 +84,7 @@ func (b *arccache) Has(k cid.Cid) (bool, error) {
 	return has, nil
 }
 
-func (b *arccache) GetSize(k cid.Cid) (int, error) {
+func (b *arccache) GetSize(ctx context.Context, k cid.Cid) (int, error) {
 	if has, blockSize, ok := b.hasCached(k); ok {
 		if !has {
 			// don't have it, return
@@ -96,7 +96,7 @@ func (b *arccache) GetSize(k cid.Cid) (int, error) {
 		}
 		// we have it but don't know the size, ask the datastore.
 	}
-	blockSize, err := b.blockstore.GetSize(k)
+	blockSize, err := b.blockstore.GetSize(ctx, k)
 	if err == ErrNotFound {
 		b.cacheHave(k, false)
 	} else if err == nil {
@@ -105,7 +105,7 @@ func (b *arccache) GetSize(k cid.Cid) (int, error) {
 	return blockSize, err
 }
 
-func (b *arccache) Get(k cid.Cid) (blocks.Block, error) {
+func (b *arccache) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 	if !k.Defined() {
 		log.Error("undefined cid in arc cache")
 		return nil, ErrNotFound
@@ -115,7 +115,7 @@ func (b *arccache) Get(k cid.Cid) (blocks.Block, error) {
 		return nil, ErrNotFound
 	}
 
-	bl, err := b.blockstore.Get(k)
+	bl, err := b.blockstore.Get(ctx, k)
 	if bl == nil && err == ErrNotFound {
 		b.cacheHave(k, false)
 	} else if bl != nil {
@@ -124,19 +124,19 @@ func (b *arccache) Get(k cid.Cid) (blocks.Block, error) {
 	return bl, err
 }
 
-func (b *arccache) Put(bl blocks.Block) error {
+func (b *arccache) Put(ctx context.Context, bl blocks.Block) error {
 	if has, _, ok := b.hasCached(bl.Cid()); ok && has {
 		return nil
 	}
 
-	err := b.blockstore.Put(bl)
+	err := b.blockstore.Put(ctx, bl)
 	if err == nil {
 		b.cacheSize(bl.Cid(), len(bl.RawData()))
 	}
 	return err
 }
 
-func (b *arccache) PutMany(bs []blocks.Block) error {
+func (b *arccache) PutMany(ctx context.Context, bs []blocks.Block) error {
 	var good []blocks.Block
 	for _, block := range bs {
 		// call put on block if result is inconclusive or we are sure that
@@ -145,7 +145,7 @@ func (b *arccache) PutMany(bs []blocks.Block) error {
 			good = append(good, block)
 		}
 	}
-	err := b.blockstore.PutMany(good)
+	err := b.blockstore.PutMany(ctx, good)
 	if err != nil {
 		return err
 	}

--- a/bloom_cache.go
+++ b/bloom_cache.go
@@ -111,12 +111,12 @@ func (b *bloomcache) build(ctx context.Context) error {
 	}
 }
 
-func (b *bloomcache) DeleteBlock(k cid.Cid) error {
+func (b *bloomcache) DeleteBlock(ctx context.Context, k cid.Cid) error {
 	if has, ok := b.hasCached(k); ok && !has {
 		return nil
 	}
 
-	return b.blockstore.DeleteBlock(k)
+	return b.blockstore.DeleteBlock(ctx, k)
 }
 
 // if ok == false has is inconclusive
@@ -139,41 +139,41 @@ func (b *bloomcache) hasCached(k cid.Cid) (has bool, ok bool) {
 	return false, false
 }
 
-func (b *bloomcache) Has(k cid.Cid) (bool, error) {
+func (b *bloomcache) Has(ctx context.Context, k cid.Cid) (bool, error) {
 	if has, ok := b.hasCached(k); ok {
 		return has, nil
 	}
 
-	return b.blockstore.Has(k)
+	return b.blockstore.Has(ctx, k)
 }
 
-func (b *bloomcache) GetSize(k cid.Cid) (int, error) {
-	return b.blockstore.GetSize(k)
+func (b *bloomcache) GetSize(ctx context.Context, k cid.Cid) (int, error) {
+	return b.blockstore.GetSize(ctx, k)
 }
 
-func (b *bloomcache) Get(k cid.Cid) (blocks.Block, error) {
+func (b *bloomcache) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 	if has, ok := b.hasCached(k); ok && !has {
 		return nil, ErrNotFound
 	}
 
-	return b.blockstore.Get(k)
+	return b.blockstore.Get(ctx, k)
 }
 
-func (b *bloomcache) Put(bl blocks.Block) error {
+func (b *bloomcache) Put(ctx context.Context, bl blocks.Block) error {
 	// See comment in PutMany
-	err := b.blockstore.Put(bl)
+	err := b.blockstore.Put(ctx, bl)
 	if err == nil {
 		b.bloom.AddTS(bl.Cid().Hash())
 	}
 	return err
 }
 
-func (b *bloomcache) PutMany(bs []blocks.Block) error {
+func (b *bloomcache) PutMany(ctx context.Context, bs []blocks.Block) error {
 	// bloom cache gives only conclusive resulty if key is not contained
 	// to reduce number of puts we need conclusive information if block is contained
 	// this means that PutMany can't be improved with bloom cache so we just
 	// just do a passthrough.
-	err := b.blockstore.PutMany(bs)
+	err := b.blockstore.PutMany(ctx, bs)
 	if err != nil {
 		return err
 	}

--- a/bloom_cache_test.go
+++ b/bloom_cache_test.go
@@ -27,6 +27,8 @@ func testBloomCached(ctx context.Context, bs Blockstore) (*bloomcache, error) {
 }
 
 func TestPutManyAddsToBloom(t *testing.T) {
+	ctx := context.Background()
+
 	bs := NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -45,12 +47,12 @@ func TestPutManyAddsToBloom(t *testing.T) {
 	block2 := blocks.NewBlock([]byte("bar"))
 	emptyBlock := blocks.NewBlock([]byte{})
 
-	cachedbs.PutMany([]blocks.Block{block1, emptyBlock})
-	has, err := cachedbs.Has(block1.Cid())
+	cachedbs.PutMany(ctx, []blocks.Block{block1, emptyBlock})
+	has, err := cachedbs.Has(ctx, block1.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
-	blockSize, err := cachedbs.GetSize(block1.Cid())
+	blockSize, err := cachedbs.GetSize(ctx, block1.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,11 +60,11 @@ func TestPutManyAddsToBloom(t *testing.T) {
 		t.Fatal("added block is reported missing")
 	}
 
-	has, err = cachedbs.Has(block2.Cid())
+	has, err = cachedbs.Has(ctx, block2.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
-	blockSize, err = cachedbs.GetSize(block2.Cid())
+	blockSize, err = cachedbs.GetSize(ctx, block2.Cid())
 	if err != nil && err != ErrNotFound {
 		t.Fatal(err)
 	}
@@ -70,11 +72,11 @@ func TestPutManyAddsToBloom(t *testing.T) {
 		t.Fatal("not added block is reported to be in blockstore")
 	}
 
-	has, err = cachedbs.Has(emptyBlock.Cid())
+	has, err = cachedbs.Has(ctx, emptyBlock.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
-	blockSize, err = cachedbs.GetSize(emptyBlock.Cid())
+	blockSize, err = cachedbs.GetSize(ctx, emptyBlock.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,11 +93,13 @@ func TestReturnsErrorWhenSizeNegative(t *testing.T) {
 	}
 }
 func TestHasIsBloomCached(t *testing.T) {
+	ctx := context.Background()
+
 	cd := &callbackDatastore{f: func() {}, ds: ds.NewMapDatastore()}
 	bs := NewBlockstore(syncds.MutexWrap(cd))
 
 	for i := 0; i < 1000; i++ {
-		bs.Put(blocks.NewBlock([]byte(fmt.Sprintf("data: %d", i))))
+		bs.Put(ctx, blocks.NewBlock([]byte(fmt.Sprintf("data: %d", i))))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -115,7 +119,7 @@ func TestHasIsBloomCached(t *testing.T) {
 	})
 
 	for i := 0; i < 1000; i++ {
-		cachedbs.Has(blocks.NewBlock([]byte(fmt.Sprintf("data: %d", i+2000))).Cid())
+		cachedbs.Has(ctx, blocks.NewBlock([]byte(fmt.Sprintf("data: %d", i+2000))).Cid())
 	}
 
 	if float64(cacheFails)/float64(1000) > float64(0.05) {
@@ -125,20 +129,20 @@ func TestHasIsBloomCached(t *testing.T) {
 	cacheFails = 0
 	block := blocks.NewBlock([]byte("newBlock"))
 
-	cachedbs.PutMany([]blocks.Block{block})
+	cachedbs.PutMany(ctx, []blocks.Block{block})
 	if cacheFails != 2 {
 		t.Fatalf("expected two datastore hits: %d", cacheFails)
 	}
-	cachedbs.Put(block)
+	cachedbs.Put(ctx, block)
 	if cacheFails != 3 {
 		t.Fatalf("expected datastore hit: %d", cacheFails)
 	}
 
-	if has, err := cachedbs.Has(block.Cid()); !has || err != nil {
+	if has, err := cachedbs.Has(ctx, block.Cid()); !has || err != nil {
 		t.Fatal("has gave wrong response")
 	}
 
-	bl, err := cachedbs.Get(block.Cid())
+	bl, err := cachedbs.Get(ctx, block.Cid())
 	if bl.String() != block.String() {
 		t.Fatal("block data doesn't match")
 	}
@@ -168,43 +172,43 @@ func (c *callbackDatastore) CallF() {
 	c.f()
 }
 
-func (c *callbackDatastore) Put(key ds.Key, value []byte) (err error) {
+func (c *callbackDatastore) Put(ctx context.Context, key ds.Key, value []byte) (err error) {
 	c.CallF()
-	return c.ds.Put(key, value)
+	return c.ds.Put(ctx, key, value)
 }
 
-func (c *callbackDatastore) Get(key ds.Key) (value []byte, err error) {
+func (c *callbackDatastore) Get(ctx context.Context, key ds.Key) (value []byte, err error) {
 	c.CallF()
-	return c.ds.Get(key)
+	return c.ds.Get(ctx, key)
 }
 
-func (c *callbackDatastore) Has(key ds.Key) (exists bool, err error) {
+func (c *callbackDatastore) Has(ctx context.Context, key ds.Key) (exists bool, err error) {
 	c.CallF()
-	return c.ds.Has(key)
+	return c.ds.Has(ctx, key)
 }
 
-func (c *callbackDatastore) GetSize(key ds.Key) (size int, err error) {
+func (c *callbackDatastore) GetSize(ctx context.Context, key ds.Key) (size int, err error) {
 	c.CallF()
-	return c.ds.GetSize(key)
+	return c.ds.GetSize(ctx, key)
 }
 
 func (c *callbackDatastore) Close() error {
 	return nil
 }
 
-func (c *callbackDatastore) Delete(key ds.Key) (err error) {
+func (c *callbackDatastore) Delete(ctx context.Context, key ds.Key) (err error) {
 	c.CallF()
-	return c.ds.Delete(key)
+	return c.ds.Delete(ctx, key)
 }
 
-func (c *callbackDatastore) Query(q dsq.Query) (dsq.Results, error) {
+func (c *callbackDatastore) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
 	c.CallF()
-	return c.ds.Query(q)
+	return c.ds.Query(ctx, q)
 }
 
-func (c *callbackDatastore) Sync(key ds.Key) error {
+func (c *callbackDatastore) Sync(ctx context.Context, key ds.Key) error {
 	c.CallF()
-	return c.ds.Sync(key)
+	return c.ds.Sync(ctx, key)
 }
 
 func (c *callbackDatastore) Batch() (ds.Batch, error) {

--- a/idstore.go
+++ b/idstore.go
@@ -25,47 +25,47 @@ func extractContents(k cid.Cid) (bool, []byte) {
 	return true, dmh.Digest
 }
 
-func (b *idstore) DeleteBlock(k cid.Cid) error {
+func (b *idstore) DeleteBlock(ctx context.Context, k cid.Cid) error {
 	isId, _ := extractContents(k)
 	if isId {
 		return nil
 	}
-	return b.bs.DeleteBlock(k)
+	return b.bs.DeleteBlock(ctx, k)
 }
 
-func (b *idstore) Has(k cid.Cid) (bool, error) {
+func (b *idstore) Has(ctx context.Context, k cid.Cid) (bool, error) {
 	isId, _ := extractContents(k)
 	if isId {
 		return true, nil
 	}
-	return b.bs.Has(k)
+	return b.bs.Has(ctx, k)
 }
 
-func (b *idstore) GetSize(k cid.Cid) (int, error) {
+func (b *idstore) GetSize(ctx context.Context, k cid.Cid) (int, error) {
 	isId, bdata := extractContents(k)
 	if isId {
 		return len(bdata), nil
 	}
-	return b.bs.GetSize(k)
+	return b.bs.GetSize(ctx, k)
 }
 
-func (b *idstore) Get(k cid.Cid) (blocks.Block, error) {
+func (b *idstore) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 	isId, bdata := extractContents(k)
 	if isId {
 		return blocks.NewBlockWithCid(bdata, k)
 	}
-	return b.bs.Get(k)
+	return b.bs.Get(ctx, k)
 }
 
-func (b *idstore) Put(bl blocks.Block) error {
+func (b *idstore) Put(ctx context.Context, bl blocks.Block) error {
 	isId, _ := extractContents(bl.Cid())
 	if isId {
 		return nil
 	}
-	return b.bs.Put(bl)
+	return b.bs.Put(ctx, bl)
 }
 
-func (b *idstore) PutMany(bs []blocks.Block) error {
+func (b *idstore) PutMany(ctx context.Context, bs []blocks.Block) error {
 	toPut := make([]blocks.Block, 0, len(bs))
 	for _, bl := range bs {
 		isId, _ := extractContents(bl.Cid())
@@ -74,7 +74,7 @@ func (b *idstore) PutMany(bs []blocks.Block) error {
 		}
 		toPut = append(toPut, bl)
 	}
-	return b.bs.PutMany(toPut)
+	return b.bs.PutMany(ctx, toPut)
 }
 
 func (b *idstore) HashOnRead(enabled bool) {

--- a/idstore_test.go
+++ b/idstore_test.go
@@ -17,6 +17,8 @@ func createTestStores() (Blockstore, *callbackDatastore) {
 }
 
 func TestIdStore(t *testing.T) {
+	ctx := context.Background()
+
 	idhash1, _ := cid.NewPrefixV1(cid.Raw, mh.ID).Sum([]byte("idhash1"))
 	idblock1, _ := blk.NewBlockWithCid([]byte("idhash1"), idhash1)
 	hash1, _ := cid.NewPrefixV1(cid.Raw, mh.SHA2_256).Sum([]byte("hash1"))
@@ -26,12 +28,12 @@ func TestIdStore(t *testing.T) {
 
 	ids, cb := createTestStores()
 
-	have, _ := ids.Has(idhash1)
+	have, _ := ids.Has(ctx, idhash1)
 	if !have {
 		t.Fatal("Has() failed on idhash")
 	}
 
-	_, err := ids.Get(idhash1)
+	_, err := ids.Get(ctx, idhash1)
 	if err != nil {
 		t.Fatalf("Get() failed on idhash: %v", err)
 	}
@@ -42,70 +44,70 @@ func TestIdStore(t *testing.T) {
 	}
 
 	cb.f = failIfPassThough
-	err = ids.Put(idblock1)
+	err = ids.Put(ctx, idblock1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cb.f = noop
-	err = ids.Put(block1)
+	err = ids.Put(ctx, block1)
 	if err != nil {
 		t.Fatalf("Put() failed on normal block: %v", err)
 	}
 
-	have, _ = ids.Has(hash1)
+	have, _ = ids.Has(ctx, hash1)
 	if !have {
 		t.Fatal("normal block not added to datastore")
 	}
 
-	blockSize, _ := ids.GetSize(hash1)
+	blockSize, _ := ids.GetSize(ctx, hash1)
 	if blockSize == -1 {
 		t.Fatal("normal block not added to datastore")
 	}
 
-	_, err = ids.Get(hash1)
+	_, err = ids.Get(ctx, hash1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = ids.Put(emptyBlock)
+	err = ids.Put(ctx, emptyBlock)
 	if err != nil {
 		t.Fatalf("Put() failed on normal block: %v", err)
 	}
 
-	have, _ = ids.Has(emptyHash)
+	have, _ = ids.Has(ctx, emptyHash)
 	if !have {
 		t.Fatal("normal block not added to datastore")
 	}
 
-	blockSize, _ = ids.GetSize(emptyHash)
+	blockSize, _ = ids.GetSize(ctx, emptyHash)
 	if blockSize != 0 {
 		t.Fatal("normal block not added to datastore")
 	}
 
 	cb.f = failIfPassThough
-	err = ids.DeleteBlock(idhash1)
+	err = ids.DeleteBlock(ctx, idhash1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cb.f = noop
-	err = ids.DeleteBlock(hash1)
+	err = ids.DeleteBlock(ctx, hash1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	have, _ = ids.Has(hash1)
+	have, _ = ids.Has(ctx, hash1)
 	if have {
 		t.Fatal("normal block not deleted from datastore")
 	}
 
-	blockSize, _ = ids.GetSize(hash1)
+	blockSize, _ = ids.GetSize(ctx, hash1)
 	if blockSize > -1 {
 		t.Fatal("normal block not deleted from datastore")
 	}
 
-	err = ids.DeleteBlock(emptyHash)
+	err = ids.DeleteBlock(ctx, emptyHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +118,7 @@ func TestIdStore(t *testing.T) {
 	block2, _ := blk.NewBlockWithCid([]byte("hash2"), hash2)
 
 	cb.f = failIfPassThough
-	err = ids.PutMany([]blk.Block{idblock1, idblock2})
+	err = ids.PutMany(ctx, []blk.Block{idblock1, idblock2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +128,7 @@ func TestIdStore(t *testing.T) {
 		opCount++
 	}
 
-	err = ids.PutMany([]blk.Block{block1, block2})
+	err = ids.PutMany(ctx, []blk.Block{block1, block2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +138,7 @@ func TestIdStore(t *testing.T) {
 	}
 
 	opCount = 0
-	err = ids.PutMany([]blk.Block{idblock1, block1})
+	err = ids.PutMany(ctx, []blk.Block{idblock1, block1})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Master issue: https://github.com/ipfs/go-ipfs/issues/6803

This only do the wiring. Actual usage for cancellation, logging or tracing is
left for a future work.