### PR TITLE
feat: per-cid locking

### DIFF
--- a/arc_cache.go
+++ b/arc_cache.go
@@ -2,6 +2,7 @@ package blockstore
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -13,13 +14,20 @@ import (
 type cacheHave bool
 type cacheSize int
 
+type lock struct {
+	mu     sync.RWMutex
+	refcnt int
+}
+
 // arccache wraps a BlockStore with an Adaptive Replacement Cache (ARC) that
 // does not store the actual blocks, just metadata about them: existence and
 // size. This provides block access-time improvements, allowing
 // to short-cut many searches without querying the underlying datastore.
 type arccache struct {
+	lklk sync.Mutex
+	lks  map[string]*lock
+
 	cache *lru.TwoQueueCache
-	lks   [256]sync.RWMutex
 
 	blockstore Blockstore
 	viewer     Viewer
@@ -36,7 +44,7 @@ func newARCCachedBS(ctx context.Context, bs Blockstore, lruSize int) (*arccache,
 	if err != nil {
 		return nil, err
 	}
-	c := &arccache{cache: cache, blockstore: bs}
+	c := &arccache{cache: cache, blockstore: bs, lks: make(map[string]*lock)}
 	c.hits = metrics.NewCtx(ctx, "arc.hits_total", "Number of ARC cache hits").Counter()
 	c.total = metrics.NewCtx(ctx, "arc_total", "Total number of ARC cache requests").Counter()
 	if v, ok := bs.(Viewer); ok {
@@ -45,12 +53,39 @@ func newARCCachedBS(ctx context.Context, bs Blockstore, lruSize int) (*arccache,
 	return c, nil
 }
 
-func (b *arccache) getLock(k cid.Cid) *sync.RWMutex {
-	return &b.lks[mutexKey(k)]
+func (b *arccache) lock(k string, write bool) {
+	b.lklk.Lock()
+	lk, ok := b.lks[k]
+	if !ok {
+		lk = new(lock)
+		b.lks[k] = lk
+	}
+	lk.refcnt++
+	b.lklk.Unlock()
+	if write {
+		lk.mu.Lock()
+	} else {
+		lk.mu.RLock()
+	}
 }
 
-func mutexKey(k cid.Cid) uint8 {
-	return k.KeyString()[len(k.KeyString())-1]
+func (b *arccache) unlock(key string, write bool) {
+	b.lklk.Lock()
+	lk := b.lks[key]
+	lk.refcnt--
+	if lk.refcnt == 0 {
+		delete(b.lks, key)
+	}
+	b.lklk.Unlock()
+	if write {
+		lk.mu.Unlock()
+	} else {
+		lk.mu.RUnlock()
+	}
+}
+
+func cacheKey(k cid.Cid) string {
+	return string(k.Hash())
 }
 
 func (b *arccache) DeleteBlock(ctx context.Context, k cid.Cid) error {
@@ -58,18 +93,20 @@ func (b *arccache) DeleteBlock(ctx context.Context, k cid.Cid) error {
 		return nil
 	}
 
-	if has, _, ok := b.queryCache(k); ok && !has {
+	key := cacheKey(k)
+
+	if has, _, ok := b.queryCache(key); ok && !has {
 		return nil
 	}
 
-	lk := b.getLock(k)
-	lk.Lock()
-	defer lk.Unlock()
+	b.lock(key, true)
+	defer b.unlock(key, true)
 
-	b.cache.Remove(k) // Invalidate cache before deleting.
 	err := b.blockstore.DeleteBlock(ctx, k)
 	if err == nil {
-		b.cacheHave(k, false)
+		b.cacheHave(key, false)
+	} else {
+		b.cacheInvalidate(key)
 	}
 	return err
 }
@@ -79,19 +116,20 @@ func (b *arccache) Has(ctx context.Context, k cid.Cid) (bool, error) {
 		return false, nil
 	}
 
-	if has, _, ok := b.queryCache(k); ok {
+	key := cacheKey(k)
+
+	if has, _, ok := b.queryCache(key); ok {
 		return has, nil
 	}
 
-	lk := b.getLock(k)
-	lk.RLock()
-	defer lk.RUnlock()
+	b.lock(key, false)
+	defer b.unlock(key, false)
 
 	has, err := b.blockstore.Has(ctx, k)
 	if err != nil {
 		return false, err
 	}
-	b.cacheHave(k, has)
+	b.cacheHave(key, has)
 	return has, nil
 }
 
@@ -100,7 +138,9 @@ func (b *arccache) GetSize(ctx context.Context, k cid.Cid) (int, error) {
 		return -1, ErrNotFound
 	}
 
-	if has, blockSize, ok := b.queryCache(k); ok {
+	key := cacheKey(k)
+
+	if has, blockSize, ok := b.queryCache(key); ok {
 		if !has {
 			// don't have it, return
 			return -1, ErrNotFound
@@ -112,15 +152,14 @@ func (b *arccache) GetSize(ctx context.Context, k cid.Cid) (int, error) {
 		// we have it but don't know the size, ask the datastore.
 	}
 
-	lk := b.getLock(k)
-	lk.RLock()
-	defer lk.RUnlock()
+	b.lock(key, false)
+	defer b.unlock(key, false)
 
 	blockSize, err := b.blockstore.GetSize(ctx, k)
 	if err == ErrNotFound {
-		b.cacheHave(k, false)
+		b.cacheHave(key, false)
 	} else if err == nil {
-		b.cacheSize(k, blockSize)
+		b.cacheSize(key, blockSize)
 	}
 	return blockSize, err
 }
@@ -140,17 +179,33 @@ func (b *arccache) View(ctx context.Context, k cid.Cid, callback func([]byte) er
 		return ErrNotFound
 	}
 
-	if has, _, ok := b.queryCache(k); ok && !has {
+	key := cacheKey(k)
+
+	if has, _, ok := b.queryCache(key); ok && !has {
 		// short circuit if the cache deterministically tells us the item
 		// doesn't exist.
 		return ErrNotFound
 	}
 
-	lk := b.getLock(k)
-	lk.RLock()
-	defer lk.RUnlock()
+	b.lock(key, false)
+	defer b.unlock(key, false)
 
-	return b.viewer.View(ctx, k, callback)
+	var cberr error
+	var size int
+	if err := b.viewer.View(ctx, k, func(buf []byte) error {
+		size = len(buf)
+		cberr = callback(buf)
+		return nil
+	}); err != nil {
+		if err == ErrNotFound {
+			b.cacheHave(key, false)
+		}
+		return err
+	}
+
+	b.cacheSize(key, size)
+
+	return cberr
 }
 
 func (b *arccache) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
@@ -158,72 +213,134 @@ func (b *arccache) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 		return nil, ErrNotFound
 	}
 
-	if has, _, ok := b.queryCache(k); ok && !has {
+	key := cacheKey(k)
+
+	if has, _, ok := b.queryCache(key); ok && !has {
 		return nil, ErrNotFound
 	}
 
-	lk := b.getLock(k)
-	lk.RLock()
-	defer lk.RUnlock()
+	b.lock(key, false)
+	defer b.unlock(key, false)
 
 	bl, err := b.blockstore.Get(ctx, k)
 	if bl == nil && err == ErrNotFound {
-		b.cacheHave(k, false)
+		b.cacheHave(key, false)
 	} else if bl != nil {
-		b.cacheSize(k, len(bl.RawData()))
+		b.cacheSize(key, len(bl.RawData()))
 	}
 	return bl, err
 }
 
 func (b *arccache) Put(ctx context.Context, bl blocks.Block) error {
-	if has, _, ok := b.queryCache(bl.Cid()); ok && has {
+	key := cacheKey(bl.Cid())
+
+	if has, _, ok := b.queryCache(key); ok && has {
 		return nil
 	}
 
-	lk := b.getLock(bl.Cid())
-	lk.Lock()
-	defer lk.Unlock()
+	b.lock(key, true)
+	defer b.unlock(key, true)
 
 	err := b.blockstore.Put(ctx, bl)
 	if err == nil {
-		b.cacheSize(bl.Cid(), len(bl.RawData()))
+		b.cacheSize(key, len(bl.RawData()))
+	} else {
+		b.cacheInvalidate(key)
 	}
 	return err
 }
 
+type keyedBlocks struct {
+	keys   []string
+	blocks []blocks.Block
+}
+
+func (b *keyedBlocks) Len() int {
+	return len(b.keys)
+}
+
+func (b *keyedBlocks) Less(i, j int) bool {
+	return b.keys[i] < b.keys[j]
+}
+
+func (b *keyedBlocks) Swap(i, j int) {
+	b.keys[i], b.keys[j] = b.keys[j], b.keys[i]
+	b.blocks[i], b.blocks[j] = b.blocks[j], b.blocks[i]
+}
+
+func (b *keyedBlocks) append(key string, blk blocks.Block) {
+	b.keys = append(b.keys, key)
+	b.blocks = append(b.blocks, blk)
+}
+
+func (b *keyedBlocks) isEmpty() bool {
+	return len(b.keys) == 0
+}
+
+func (b *keyedBlocks) sortAndDedup() {
+	if b.isEmpty() {
+		return
+	}
+
+	sort.Sort(b)
+
+	// https://github.com/golang/go/wiki/SliceTricks#in-place-deduplicate-comparable
+	j := 0
+	for i := 1; i < len(b.keys); i++ {
+		if b.keys[j] == b.keys[i] {
+			continue
+		}
+		j++
+		b.keys[j] = b.keys[i]
+		b.blocks[j] = b.blocks[i]
+	}
+
+	b.keys = b.keys[:j+1]
+	b.blocks = b.blocks[:j+1]
+}
+
+func newKeyedBlocks(cap int) *keyedBlocks {
+	return &keyedBlocks{
+		keys:   make([]string, 0, cap),
+		blocks: make([]blocks.Block, 0, cap),
+	}
+}
+
 func (b *arccache) PutMany(ctx context.Context, bs []blocks.Block) error {
-	mxs := [256]*sync.RWMutex{}
-	var good []blocks.Block
-	for _, block := range bs {
+	good := newKeyedBlocks(len(bs))
+	for _, blk := range bs {
 		// call put on block if result is inconclusive or we are sure that
 		// the block isn't in storage
-		if has, _, ok := b.queryCache(block.Cid()); !ok || (ok && !has) {
-			good = append(good, block)
-			mxs[mutexKey(block.Cid())] = &b.lks[mutexKey(block.Cid())]
+		key := cacheKey(blk.Cid())
+		if has, _, ok := b.queryCache(key); !ok || (ok && !has) {
+			good.append(key, blk)
 		}
 	}
 
-	for _, mx := range mxs {
-		if mx != nil {
-			mx.Lock()
-		}
+	if good.isEmpty() {
+		return nil
+	}
+
+	good.sortAndDedup()
+
+	for _, key := range good.keys {
+		b.lock(key, true)
 	}
 
 	defer func() {
-		for _, mx := range mxs {
-			if mx != nil {
-				mx.Unlock()
-			}
+		for _, key := range good.keys {
+			b.unlock(key, true)
 		}
 	}()
 
-	err := b.blockstore.PutMany(ctx, good)
+	err := b.blockstore.PutMany(ctx, good.blocks)
 	if err != nil {
 		return err
 	}
-	for _, block := range good {
-		b.cacheSize(block.Cid(), len(block.RawData()))
+	for i, key := range good.keys {
+		b.cacheSize(key, len(good.blocks[i].RawData()))
 	}
+
 	return nil
 }
 
@@ -231,12 +348,16 @@ func (b *arccache) HashOnRead(enabled bool) {
 	b.blockstore.HashOnRead(enabled)
 }
 
-func (b *arccache) cacheHave(c cid.Cid, have bool) {
-	b.cache.Add(string(c.Hash()), cacheHave(have))
+func (b *arccache) cacheHave(key string, have bool) {
+	b.cache.Add(key, cacheHave(have))
 }
 
-func (b *arccache) cacheSize(c cid.Cid, blockSize int) {
-	b.cache.Add(string(c.Hash()), cacheSize(blockSize))
+func (b *arccache) cacheSize(key string, blockSize int) {
+	b.cache.Add(key, cacheSize(blockSize))
+}
+
+func (b *arccache) cacheInvalidate(key string) {
+	b.cache.Remove(key)
 }
 
 // queryCache checks if the CID is in the cache. If so, it returns:
@@ -250,16 +371,10 @@ func (b *arccache) cacheSize(c cid.Cid, blockSize int) {
 //
 // When ok is true, exists carries the correct answer, and size carries the
 // size, if known, or -1 if not.
-func (b *arccache) queryCache(k cid.Cid) (exists bool, size int, ok bool) {
+func (b *arccache) queryCache(k string) (exists bool, size int, ok bool) {
 	b.total.Inc()
-	if !k.Defined() {
-		log.Error("undefined cid in arccache")
-		// Return cache invalid so the call to blockstore happens
-		// in case of invalid key and correct error is created.
-		return false, -1, false
-	}
 
-	h, ok := b.cache.Get(string(k.Hash()))
+	h, ok := b.cache.Get(k)
 	if ok {
 		b.hits.Inc()
 		switch h := h.(type) {


### PR DESCRIPTION
Unfortunately, stripped locking breaks down when doing many concurrent operations. Luckily, per-cid locking isn't that expensive.

In my benchmarks, it doesn't even make a noticeable difference. Probably because I also optimized some things to avoid re-computing the cache key multiple times.