### PR TITLE
fix: remove context from HashOnRead

### DIFF
--- a/arc_cache.go
+++ b/arc_cache.go
@@ -227,8 +227,8 @@ func (b *arccache) PutMany(ctx context.Context, bs []blocks.Block) error {
 	return nil
 }
 
-func (b *arccache) HashOnRead(ctx context.Context, enabled bool) {
-	b.blockstore.HashOnRead(ctx, enabled)
+func (b *arccache) HashOnRead(enabled bool) {
+	b.blockstore.HashOnRead(enabled)
 }
 
 func (b *arccache) cacheHave(c cid.Cid, have bool) {

--- a/blockstore.go
+++ b/blockstore.go
@@ -54,7 +54,7 @@ type Blockstore interface {
 
 	// HashOnRead specifies if every read block should be
 	// rehashed to make sure it matches its CID.
-	HashOnRead(ctx context.Context, enabled bool)
+	HashOnRead(enabled bool)
 }
 
 // Viewer can be implemented by blockstores that offer zero-copy access to
@@ -137,7 +137,7 @@ type blockstore struct {
 	rehash *uatomic.Bool
 }
 
-func (bs *blockstore) HashOnRead(_ context.Context, enabled bool) {
+func (bs *blockstore) HashOnRead(enabled bool) {
 	bs.rehash.Store(enabled)
 }
 

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -152,7 +152,7 @@ func TestHashOnRead(t *testing.T) {
 	bl2 := blocks.NewBlock([]byte("some other data"))
 	bs.Put(bg, blBad)
 	bs.Put(bg, bl2)
-	bs.HashOnRead(bg, true)
+	bs.HashOnRead(true)
 
 	if _, err := bs.Get(bg, bl.Cid()); err != ErrHashMismatch {
 		t.Fatalf("expected '%v' got '%v'\n", ErrHashMismatch, err)

--- a/bloom_cache.go
+++ b/bloom_cache.go
@@ -209,8 +209,8 @@ func (b *bloomcache) PutMany(ctx context.Context, bs []blocks.Block) error {
 	return nil
 }
 
-func (b *bloomcache) HashOnRead(ctx context.Context, enabled bool) {
-	b.blockstore.HashOnRead(ctx, enabled)
+func (b *bloomcache) HashOnRead(enabled bool) {
+	b.blockstore.HashOnRead(enabled)
 }
 
 func (b *bloomcache) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ require (
 	github.com/ipfs/bbloom v0.0.4
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.7
-	github.com/ipfs/go-datastore v0.4.7-0.20211013204805-28a3721c2e66
-	github.com/ipfs/go-ipfs-ds-help v1.0.0
+	github.com/ipfs/go-datastore v0.5.0
+	github.com/ipfs/go-ipfs-ds-help v1.1.0
 	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-log v0.0.1
 	github.com/ipfs/go-metrics-interface v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -16,14 +16,13 @@ github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WW
 github.com/ipfs/go-cid v0.0.5/go.mod h1:plgt+Y5MnOey4vO4UlUazGqdbEXuFYitED67FexhXog=
 github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
-github.com/ipfs/go-datastore v0.4.1/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
-github.com/ipfs/go-datastore v0.4.7-0.20211013204805-28a3721c2e66 h1:1aC1rf4yupEhdEx+MnwadLRq7cdj+SDgOs7jfxqCT/c=
-github.com/ipfs/go-datastore v0.4.7-0.20211013204805-28a3721c2e66/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
+github.com/ipfs/go-datastore v0.5.0 h1:rQicVCEacWyk4JZ6G5bD9TKR7lZEG1MWcG7UdWYrFAU=
+github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
-github.com/ipfs/go-ipfs-ds-help v1.0.0 h1:bEQ8hMGs80h0sR8O4tfDgV6B01aaF9qeTrujrTLYV3g=
-github.com/ipfs/go-ipfs-ds-help v1.0.0/go.mod h1:ujAbkeIgkKAWtxxNkoZHWLCyk5JpPoKnGyCcsoF6ueE=
+github.com/ipfs/go-ipfs-ds-help v1.1.0 h1:yLE2w9RAsl31LtfMt91tRZcrx+e61O5mDxFRR994w4Q=
+github.com/ipfs/go-ipfs-ds-help v1.1.0/go.mod h1:YR5+6EaebOhfcqVCyqemItCLthrpVNot+rsOU/5IatU=
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-ipfs-util v0.0.2/go.mod h1:CbPtkWJzjLdEcezDns2XYaehFVNXG9zrdrtMecczcsQ=
 github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=
@@ -31,7 +30,6 @@ github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9
 github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fGD6n0jO4kdg=
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
-github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsjFq/qrU3Rar62tu1gASgGw6chQbSh/XgIIXCY=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/idstore.go
+++ b/idstore.go
@@ -107,8 +107,8 @@ func (b *idstore) PutMany(ctx context.Context, bs []blocks.Block) error {
 	return b.bs.PutMany(ctx, toPut)
 }
 
-func (b *idstore) HashOnRead(ctx context.Context, enabled bool) {
-	b.bs.HashOnRead(ctx, enabled)
+func (b *idstore) HashOnRead(enabled bool) {
+	b.bs.HashOnRead(enabled)
 }
 
 func (b *idstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.1.0"
+  "version": "v1.1.1"
 }


### PR DESCRIPTION
This is so that v0 and v1 have identical interfaces, which is required
to avoid massive pain for consumers like estuary. Since we have
already plumbed v0 all the way through, it's easiest to just remove
the probably-unnecessary context from HashOnRead.