### PR TITLE
feat: fast-path for PutMany, falling back to Put for single block call

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -180,6 +180,11 @@ func (bs *blockstore) Put(ctx context.Context, block blocks.Block) error {
 }
 
 func (bs *blockstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
+	if len(blocks) == 1 {
+		// performance fast-path
+		return bs.Put(ctx, blocks[0])
+	}
+
 	t, err := bs.datastore.Batch(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This avoid the batching overhead.

It's for example called [in blockservice](https://github.com/ipfs/go-blockservice/blob/master/blockservice.go#L189), regardless of how many blocks are added.