### PR TITLE
Allow using a NewWriteThrough() blockstore.

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -145,10 +145,18 @@ func NewBlockstore(d ds.Batching, opts ...Option) Blockstore {
 	}
 
 	if !bs.noPrefix {
-		dd := dsns.Wrap(d, BlockPrefix)
-		bs.datastore = dd
+		bs.datastore = dsns.Wrap(bs.datastore, BlockPrefix)
 	}
 	return bs
+}
+
+// NewBlockstoreNoPrefix returns a default Blockstore implementation
+// using the provided datastore.Batching backend.
+// This constructor does not modify input keys in any way
+//
+// Deprecated: Use NewBlockstore with the NoPrefix option instead.
+func NewBlockstoreNoPrefix(d ds.Batching) Blockstore {
+	return NewBlockstore(d, NoPrefix())
 }
 
 type blockstore struct {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.2.0"
+  "version": "v1.3.0"
 }


### PR DESCRIPTION
Similar to blockservice.NewWriteThrough().

Currently the default blockstore trades read amplification for every write. While this is fine in cases where writes are very expensive and the datastore offers a quick Has() method, it is not always the case.

Some datastore backends may be better off just getting all the writes no matter what. At least I would like to try it out.